### PR TITLE
Fix: Correct redirect for new users after login

### DIFF
--- a/packages/dashboard/src/app/api/auth/[...nextauth]/route.ts
+++ b/packages/dashboard/src/app/api/auth/[...nextauth]/route.ts
@@ -59,7 +59,7 @@ const createAuthHandler = () => {
     adapter: PrismaAdapter(prisma),
     pages: {
       signIn: "/auth/signin",
-      newUser: "/onboarding",
+      // newUser: "/onboarding",
     },
     session: {
       strategy: "jwt",


### PR DESCRIPTION
Previously, new users were redirected to a non-existent `/onboarding` page due to the `pages.newUser` configuration in NextAuth.js, resulting in a 404 error.

This commit resolves the issue by commenting out the `newUser: "/onboarding"` line in the NextAuth.js options. New users will now be redirected to the `/dashboard` page, consistent with the `callbackUrl` specified in the sign-in flow and the behavior for existing users.